### PR TITLE
Add helper methods to separate dataset formatting for each state - merge with main

### DIFF
--- a/lib/dmv.rb
+++ b/lib/dmv.rb
@@ -27,223 +27,69 @@ class Dmv
     #Each state may have different API, and so we need a 'dispatching' method here
     #FOR NOW: just code this for Colorado, then can break it out from there for addt'l states
     #Also coded for NY and MO (that's all for this project)
-    if state == "Colorado"
-      # hash = get_facilities_data_colorado(facilities_incoming_data)
-      facilities_incoming_data.each do |facility|
-        # new_facility = Facility.new(facility_parameters(facility))
-        facility_info = {
-          name: facility[:dmv_office],
-          address: "#{facility[:address_li]} #{facility[:address__1]} #{facility[:location]} #{facility[:city]} #{facility[:state]} #{facility[:zip]}",
-          phone: facility[:phone],
-          hours: facility[:hours]       #Iteration 4: add hours (direct copy for CO)
-        }
 
-        #Create facility
-        new_facility = Facility.new(facility_info)
-        add_facility(new_facility)
-
-        #Now add services (to stay with spirit of preexisting codebase - even though they abandoned us!)
-        #Need to convert API's listing of services to our format.  Don't think there's a cleaner way to do this than a use of 'case' or similar:
-        #Can either grab the next 'token' and analyze, or search for specific terms;
-        #I'll go with latter option for now
-        new_facility.add_service("New Drivers License") if facility[:services_p].include?("registration")
-        new_facility.add_service("Renew Drivers License") if facility[:services_p].include?("renew")
-        #NOTE: they don't seem to have granularity in their services regarding tests;
-        #so, I'm going to assume they offer them by default.  CHECK THIS ASSUMPTION
-        new_facility.add_service("Written Test")
-        new_facility.add_service("Road Test")
+    facilities_incoming_data.each do |facility_data|
+      #Construct facility based on state, since dataset must be converted differently due to idiosyncracies in each case
+      if state == "Colorado"
+        new_facility = Facility.new(facility_parameters_co(facility_data))
+      elsif state == "New York"
+        new_facility = Facility.new(facility_parameters_ny(facility_data))
+      elsif state == "Missouri"
+        new_facility = Facility.new(facility_parameters_mo(facility_data))
       end
 
-    end
+      add_facility(new_facility)
 
-    #Better (refactor later): write a fetcher function that depends on state - that's the only thing that really changes here...
-    #Well, there could be issues with services as well...we'll see...
-    if state == "New York"
-      facilities_incoming_data.each do |facility|
-        #Pre-determine name, since this one is nasty, have to concatenate and then 'fix' capitlization the hard way (since each word is capitalized for a title usually)
-        name_formatted = facility[:office_name].split.map { |word| word.capitalize }
-        name_formatted << (facility[:office_type].split.map { |word| word.capitalize }).join(" ")
-        name_formatted = name_formatted.join(" ")
-
-        #Fuck this, I might write a helper method to just capitalize each word.
-        #I guess it will live in this class since it's not used anywhere else for this project
-        #(a case where OOO is kinda weird / less 'aligned')
-        #This could be tricky, though, because it needs to accept an arbitrary number of arguments (maybe pass the hash keys as symbols?).  Don't know how to do this yet...
-        address_formatted = facility[:street_address_line_1].split.map { |word| word.capitalize }
-        address_formatted << facility[:city].split.map { |word| word.capitalize }
-        address_formatted << facility[:state]
-        address_formatted << facility[:zip_code]
-        address_formatted = address_formatted.join(" ")
-
-        #Hours are listed for each day by opening and closing.  For now, I'm going to brute-force this,
-        #since no exact format is expected.  This is a mess though:
-        #This is gross...some facilities don't have keys for all M-F.  So I need to run ifs now (otherwise problems with nil)
-        hours_formatted = ""
-        #Could switch this to case / when
-        if facility.include?(:monday_beginning_hours)
-          hours_formatted = "Monday: " + facility[:monday_beginning_hours] + " - " + facility[:monday_ending_hours] + "; "
-        end
-        if facility.include?(:tuesday_beginning_hours)
-          hours_formatted << "Tuesday: " + facility[:tuesday_beginning_hours] + " - " + facility[:tuesday_ending_hours] + "; "
-        end
-        if facility.include?(:wednesday_beginning_hours)
-          hours_formatted << "Wednesday: " + facility[:wednesday_beginning_hours] + " - " + facility[:wednesday_ending_hours] + "; "
-        end
-        if facility.include?(:thursday_beginning_hours)
-          hours_formatted << "Thursday: " + facility[:thursday_beginning_hours] + " - " + facility[:thursday_ending_hours] + "; "
-        end
-        if facility.include?(:friday_beginning_hours)
-          hours_formatted << "Friday: " + facility[:friday_beginning_hours] + " - " + facility[:friday_ending_hours]
-        end
-
-        #Some of the branches don't seem to have phone numbers...make sure to process 'nil' correctly here
-        #Also, trying to keep this consistently formatted between states
-        phone = facility[:public_phone_number]
-        if phone != nil
-          phone_formatted = "(" + phone.slice(0, 3) + ") " + phone.slice(3, 3) + "-" + phone.slice(6, 4)
-        else
-          phone_formatted = "not applicable"
-        end
-
-        facility_info = {
-          name: name_formatted,
-          address: address_formatted,
-          phone: phone_formatted,
-          #Add hours (will need parsing / formatting first)
-          hours: hours_formatted
-        }
-
-        #Create facility
-        new_facility = Facility.new(facility_info)
-        add_facility(new_facility)
-
-        #Add services: NOTE - NY office API does NOT return these.
-        #I will assume ALL services are offered (is this ok?)
+      #Add services.  CO specifies some of them, so those must be checked (in furture rewrite, could remake initialize() to deal with this more cleanly too)
+      new_facility.add_service("Written Test")
+      new_facility.add_service("Road Test")
+      if state == "Colorado"
+        new_facility.add_service("New Drivers License") if facility_data[:services_p].include?("registration")
+        new_facility.add_service("Renew Drivers License") if facility_data[:services_p].include?("renew")
+      else
         new_facility.add_service("New Drivers License")
         new_facility.add_service("Renew Drivers License")
-        new_facility.add_service("Written Test")
-        new_facility.add_service("Road Test")
       end
     end
-
-    if state == "Missouri"
-      facilities_incoming_data.each do |facility|
-        #Again, like NY, this formatting could be handled in another method...
-        address_formatted = facility[:address1].delete_suffix(",")      #Certain (random?) entries end with it for some reason
-        address_formatted = "#{address_formatted} #{facility[:city]} #{facility[:state]} #{facility[:zipcode]}"
-        hours_formatted = facility[:daysopen]
-        if facility.include?(:daysclosed)
-          hours_formatted << " except for " + facility[:daysclosed]
-        end
-
-        facility_info = {
-          name: facility[:name] + " Office",       #To be as consistent with other states as possible
-          address: address_formatted,
-          phone: facility[:phone],
-          #Add hours (may need to format a little to be consistent across states)
-          #Add holidays here (since MO provides them)
-          #Need :daysopen, :daysclosed; :holidaysclosed
-          hours: hours_formatted,
-          holidays: facility[:holidaysclosed]
-        }
-
-        #Create facility
-        new_facility = Facility.new(facility_info)
-        add_facility(new_facility)
-
-        #Add services: NOTE - MO office API does NOT return these.
-        #I will assume ALL services are offered (is this ok?)
-        new_facility.add_service("New Drivers License")
-        new_facility.add_service("Renew Drivers License")
-        new_facility.add_service("Written Test")
-        new_facility.add_service("Road Test")
-      end
-
-    end
-
   end
 
   def get_ev_registration_analytics(state, specified_year)
     #Determine most popular make/model registered, the # registered for specified year, and the county with most registered vehicles
-    #Return as a hash (then helper methods can e.g. access or print part of it)
-
-    #Most popular make/model: iterate through all vehicles with all facilities
-    #Need to make a new 2D array, or a hash, that tracks model and count -> and keeps only unique entries (assume happy path that models' strings are formatted the same)
-    #This took a while to get working...in part owing to having to get everything set up correctly in the test...
-    
-    #CRITICAL: now that there are registrations from multiple states, we need to break down by state
-    #FIX THIS!!!
-    #ALSO: rename the method, since it handles vehicles beyond EVs
+    #NOTE: I kept naming based on EV vehicles.  However, now that I've extended functionality to allow NY vehicles, this method is more general,
+    #and can analyze general NY vehicles.  (With adjustments, it could also JUST analyze NY EV vehicles.) 
 
     vehicle_tally = {}
     @facilities.each do |facility|
-      #Only iterate through facilities in the specified state
       if facility.state == state
-
         facility.registered_vehicles.each do |vehicle|
-          # binding.pry
-
           if vehicle_tally.include?(vehicle.model)      #Assume just 'model' is enough (i.e. its unique and not make + model is needed)
-            vehicle_tally[vehicle.model] += 1           #Forgot to make this 'vehicle.model' for a while...was driving me crazy!
+            vehicle_tally[vehicle.model] += 1
           else
             vehicle_tally[vehicle.model] = 1
           end
         end
       end
     end
-
     #Now find the largest count in the hash:
-    #I think I need to run the max() enumerable on the values list (counts), then lookup the corresponding key (model):
     most_popular_model = vehicle_tally.key(vehicle_tally.values.max)
-    # max_count = vehicle_tally.max 
-
-    #Practice: start with array.  Find occurence of each value.
-    # array = [1, 2, 6, 5, 9, 1, 9, 4, 2, 5, 9]
-    # values_hash = {}
-    # array.each do |element|
-    #   #For each element in the array, check to see if it exists in the hash.  If so, update; if not, add at it the end.
-    #   number = values_hash.find do |number_key, count|
-    #     number_key == element
-    #   end
-    #   if number == nil
-    #     values_hash[element] = 1
-    #   else
-    #     values_hash[element] += 1
-    #   end
-    # end
-    # #Practice, more compact.  Don't need the .find enumerable, really...
-    # array = [1, 2, 6, 5, 9, 1, 9, 4, 2, 5, 9]
-    # values_hash = {}
-    # array.each do |element|
-    #   if values_hash.include?(element)
-    #     values_hash[element] += 1
-    #   else
-    #     values_hash[element] = 1
-    #   end
-    # end
-
-    #This will find if the entry already exists in the hash:
-    # number = vehicle_tally.find { |model, count| vehicle[:model] == vehicle }
 
     #Count number of occurences of given registration year in vehicle list
-    #I wonder if there are occasionally shortcuts for nested iterations...
-    vehicle_year_total = 0            #Define now for scope
+    vehicle_year_total = 0
     @facilities.each do |facility|
-      # facility.registered_vehicles.count(vehicle_to_check.registration_date.year)
-      vehicle_year_total += facility.registered_vehicles.count do |vehicle|
-        vehicle.registration_date.year == specified_year
+      if facility.state == state
+        vehicle_year_total += facility.registered_vehicles.count do |vehicle|
+          vehicle.registration_date.year == specified_year
+        end
       end
     end
 
-    #Find county (in WA) which has the most vehicle registrations.
-    #Very similar machinery to the first part above.  See if it's possible to refactor to combine these later?  (Would need fancier hash at least...)
+    #Find county which has the most vehicle registrations.  Note high machinery overlap with most popular model...a way to combine?
     county_tally = {}
     @facilities.each do |facility|
       if facility.state == state
         facility.registered_vehicles.each do |vehicle|
-          #Access vehicle's registration county here and add to tally hash
-          if county_tally.include?(vehicle.registration_county)      #Assume just 'model' is enough (i.e. its unique and not make + model is needed)
-            county_tally[vehicle.registration_county] += 1           #Forgot to make this 'vehicle.model' for a while...was driving me crazy!
+          if county_tally.include?(vehicle.registration_county)
+            county_tally[vehicle.registration_county] += 1
           else
             county_tally[vehicle.registration_county] = 1
           end
@@ -252,7 +98,87 @@ class Dmv
     end
     most_popular_county = county_tally.key(county_tally.values.max)
 
-    return {most_popular_model: most_popular_model, number_registered_for_year: vehicle_year_total, county_most_registered_vehicles: most_popular_county}
+    {most_popular_model: most_popular_model, number_registered_for_year: vehicle_year_total, county_most_registered_vehicles: most_popular_county}
+  end
+
+  def facility_parameters_co(facility_co_data)
+    #Try to centralize idiosyncratic aspects of each state's dataset to specific spots in codebase
+    #Alternate: could hosue this in Facility class.  Might try that another time - would require a different format since Facility wouldn't yet be initialized
+    {
+      name: facility_co_data[:dmv_office],
+      address: "#{facility_co_data[:address_li]} #{facility_co_data[:address__1]} #{facility_co_data[:location]} #{facility_co_data[:city]} #{facility_co_data[:state]} #{facility_co_data[:zip]}",
+      phone: facility_co_data[:phone],
+      hours: facility_co_data[:hours]       #Iteration 4: add hours (direct copy for CO)
+    }
+  end
+
+  def facility_parameters_ny(facility_ny_data)
+    #To format name: have to concatenate and then 'fix' capitlization the hard way (since each word is capitalized for a title usually)
+    name_formatted = facility_ny_data[:office_name].split.map { |word| word.capitalize }
+    name_formatted << (facility_ny_data[:office_type].split.map { |word| word.capitalize }).join(" ")
+    name_formatted = name_formatted.join(" ")
+
+    #To format address: lots of overlap here with previous entry.  If I knew how to make a method that accepted varying arguments, I might be able to; don't know this yet...
+    address_formatted = facility_ny_data[:street_address_line_1].split.map { |word| word.capitalize }
+    address_formatted << facility_ny_data[:city].split.map { |word| word.capitalize }
+    address_formatted << facility_ny_data[:state]
+    address_formatted << facility_ny_data[:zip_code]
+    address_formatted = address_formatted.join(" ")
+
+    #Hours are listed for each day by opening and closing.  For now, I'm going to brute-force this,
+    #since no exact format is expected.  This is a mess though:
+    #This is gross...some facilities don't have keys for all M-F.  So I need to run ifs now (otherwise problems with nil)
+    hours_formatted = ""
+    if facility_ny_data.include?(:monday_beginning_hours)
+      hours_formatted = "Monday: " + facility_ny_data[:monday_beginning_hours] + " - " + facility_ny_data[:monday_ending_hours] + "; "
+    end
+    if facility_ny_data.include?(:tuesday_beginning_hours)
+      hours_formatted << "Tuesday: " + facility_ny_data[:tuesday_beginning_hours] + " - " + facility_ny_data[:tuesday_ending_hours] + "; "
+    end
+    if facility_ny_data.include?(:wednesday_beginning_hours)
+      hours_formatted << "Wednesday: " + facility_ny_data[:wednesday_beginning_hours] + " - " + facility_ny_data[:wednesday_ending_hours] + "; "
+    end
+    if facility_ny_data.include?(:thursday_beginning_hours)
+      hours_formatted << "Thursday: " + facility_ny_data[:thursday_beginning_hours] + " - " + facility_ny_data[:thursday_ending_hours] + "; "
+    end
+    if facility_ny_data.include?(:friday_beginning_hours)
+      hours_formatted << "Friday: " + facility_ny_data[:friday_beginning_hours] + " - " + facility_ny_data[:friday_ending_hours]
+    end
+
+    #Some of the office don't seem to have phone numbers...make sure to process 'nil' correctly here
+    phone = facility_ny_data[:public_phone_number]
+    if phone != nil
+      phone_formatted = "(" + phone.slice(0, 3) + ") " + phone.slice(3, 3) + "-" + phone.slice(6, 4)
+    else
+      phone_formatted = "not applicable"
+    end
+
+    {
+      name: name_formatted,
+      address: address_formatted,
+      phone: phone_formatted,
+      hours: hours_formatted
+    }
+  end
+
+  def facility_parameters_mo(facility_mo_data)
+    address_formatted = facility_mo_data[:address1].delete_suffix(",")      #Certain (random?) entries end with it for some reason
+        address_formatted = "#{address_formatted} #{facility_mo_data[:city]} #{facility_mo_data[:state]} #{facility_mo_data[:zipcode]}"
+        hours_formatted = facility_mo_data[:daysopen]
+        if facility_mo_data.include?(:daysclosed)
+          hours_formatted << " except for " + facility_mo_data[:daysclosed]
+        end
+
+        facility_info = {
+          name: facility_mo_data[:name] + " Office",       #To be as consistent with other states as possible
+          address: address_formatted,
+          phone: facility_mo_data[:phone],
+          #Add hours (may need to format a little to be consistent across states)
+          #Add holidays here (since MO provides them)
+          #Need :daysopen, :daysclosed; :holidaysclosed
+          hours: hours_formatted,
+          holidays: facility_mo_data[:holidaysclosed]
+        }
   end
 
 end

--- a/spec/dmv_spec.rb
+++ b/spec/dmv_spec.rb
@@ -131,17 +131,18 @@ RSpec.describe Dmv do
       #Create the same machinery as in previous test in order to have everything set up correctly...
       factory = VehicleFactory.new()
       factory.create_vehicles(DmvDataService.new().wa_ev_registrations, "Washington")
-      @facility_1.add_service("Vehicle Registration")
+      @wa_facility.add_service("Vehicle Registration")
       factory.vehicles_manufactured.each do |vehicle|
-        @facility_1.register_vehicle(vehicle)
+        @wa_facility.register_vehicle(vehicle)
       end
-      @dmv.add_facility(@facility_1)
+      @dmv.add_facility(@wa_facility)
 
       #Because we're manually registering them now, all of them should be for 2024
       hash_2019 = @dmv.get_ev_registration_analytics("Washington", 2019)
       expect(hash_2019[:number_registered_for_year]).to eq(0)
       hash_2024 = @dmv.get_ev_registration_analytics("Washington", 2024)
-      expect(hash_2024[:number_registered_for_year]).to eq(@facility_1.registered_vehicles.length)
+
+      expect(hash_2024[:number_registered_for_year]).to eq(@wa_facility.registered_vehicles.length)
     end
 
     it 'can generate hash with correct most common county registered' do
@@ -161,8 +162,7 @@ RSpec.describe Dmv do
       expect(hash[:county_most_registered_vehicles]).to be_a(String)  #Safer, but doesn't truly see if it's working correctly
     end
 
-    it 'can generate appropriate information for both WA and NY electric vehicles' do
-      #Note: this required implementing NY vehicle registrations / creation first, of course
+    it 'can generate appropriate information for both WA and NY vehicles' do
       #Create general stuff:
       factory = VehicleFactory.new()
       @dmv.add_facility(@wa_facility)
@@ -174,12 +174,9 @@ RSpec.describe Dmv do
       factory.vehicles_manufactured.each do |vehicle|
         @wa_facility.register_vehicle(vehicle)
       end
-
-      wa_hash = @dmv.get_ev_registration_analytics("Washington", 2024)
-
-      # binding.pry
-
+      
       #Check for WA
+      wa_hash = @dmv.get_ev_registration_analytics("Washington", 2024)
       expect(wa_hash).to be_a(Hash)
       expect(wa_hash[:county_most_registered_vehicles]).to eq("King")   #Could change
 
@@ -196,6 +193,32 @@ RSpec.describe Dmv do
       expect(ny_hash[:county_most_registered_vehicles]).to eq("SUFFOLK")    #Could change
     end
 
+  end
+
+  describe '#facility_parameters_[state name]() helper methods' do
+    it 'facility_parameters_co() method returns standard formatted facility_info' do
+      colorado_facilities = DmvDataService.new.co_dmv_office_locations()
+      @dmv.create_state_facilities("Colorado", colorado_facilities)
+
+      parameters_hash = @dmv.facility_parameters_co(colorado_facilities[0])
+      expect(@dmv.facilities[0].name).to eq(parameters_hash[:name])
+    end
+
+    it 'facility_parameters_ny() method returns standard formatted facility_info' do
+      newyork_facilities = DmvDataService.new.co_dmv_office_locations()
+      @dmv.create_state_facilities("Colorado", newyork_facilities)
+
+      parameters_hash = @dmv.facility_parameters_co(newyork_facilities[0])
+      expect(@dmv.facilities[0].name).to eq(parameters_hash[:name])
+    end
+
+    it 'facility_parameters_mo() method returns standard formatted facility_info' do
+      missouri_facilities = DmvDataService.new.co_dmv_office_locations()
+      @dmv.create_state_facilities("Colorado", missouri_facilities)
+
+      parameters_hash = @dmv.facility_parameters_co(missouri_facilities[0])
+      expect(@dmv.facilities[0].name).to eq(parameters_hash[:name])
+    end
   end
 
 end


### PR DESCRIPTION
Added separate helper methods for each state (CO, NY, MO) to help separate dataset formatting to specific regions in the codebase for better organization.
Tested and functional.
Ready to merge with main branch.